### PR TITLE
Support of Polkadot Addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +562,12 @@ name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -1543,6 +1559,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bech32",
+ "blake2-rfc",
  "codespan 0.8.0",
  "codespan 0.9.5",
  "codespan-reporting 0.8.0",
@@ -1565,6 +1582,7 @@ dependencies = [
  "move-vm-types",
  "rand",
  "regex",
+ "rust-base58",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3170,6 +3188,15 @@ name = "resources"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "rust-base58"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b313b91fcdc6719ad41fa2dad2b7e810b03833fae4bf911950e15529a5f04439"
+dependencies = [
+ "num",
 ]
 
 [[package]]

--- a/dove/src/cmd/init.rs
+++ b/dove/src/cmd/init.rs
@@ -31,12 +31,16 @@ pub struct Init {
         long = "dialect",
         short = "d"
     )]
-    dialect: Option<String>
+    dialect: Option<String>,
 }
 
 impl Init {
     /// Creates a new Init command.
-    pub fn new(repository: Option<Uri>, address: Option<String>, dialect: Option<String>) -> Init {
+    pub fn new(
+        repository: Option<Uri>,
+        address: Option<String>,
+        dialect: Option<String>,
+    ) -> Init {
         Init {
             repository,
             address,

--- a/dove/src/cmd/init.rs
+++ b/dove/src/cmd/init.rs
@@ -25,14 +25,22 @@ pub struct Init {
         short = "a"
     )]
     address: Option<String>,
+    #[structopt(
+        help = "Compiler dialect",
+        name = "Dialect",
+        long = "dialect",
+        short = "d"
+    )]
+    dialect: Option<String>
 }
 
 impl Init {
     /// Creates a new Init command.
-    pub fn new(repository: Option<Uri>, address: Option<String>) -> Init {
+    pub fn new(repository: Option<Uri>, address: Option<String>, dialect: Option<String>) -> Init {
         Init {
             repository,
             address,
+            dialect,
         }
     }
 }
@@ -72,6 +80,10 @@ impl Cmd for Init {
 
         if let Some(url) = &self.repository {
             writeln!(&mut f, "blockchain_api = \"{}\"", url)?;
+        }
+
+        if let Some(dialect) = &self.dialect {
+            writeln!(&mut f, "dialect = \"{}\"", dialect)?;
         }
 
         write!(

--- a/dove/src/cmd/metadata.rs
+++ b/dove/src/cmd/metadata.rs
@@ -4,7 +4,6 @@ use crate::cmd::Cmd;
 use crate::context::Context;
 use crate::manifest::{Layout, Git, DoveToml, Package, Dependence};
 use serde::Serialize;
-use libra::prelude::AccountAddress;
 
 /// Metadata project command.
 #[derive(StructOpt, Debug)]
@@ -46,8 +45,7 @@ pub struct PackageJson {
     pub name: String,
     /// Project AccountAddress.
     #[serde(default = "code_code_address")]
-    #[serde(deserialize_with = "from_str")]
-    pub account_address: AccountAddress,
+    pub account_address: Option<String>,
     /// Authors list.
     #[serde(default)]
     pub authors: Vec<String>,

--- a/dove/src/cmd/new.rs
+++ b/dove/src/cmd/new.rs
@@ -32,7 +32,7 @@ pub struct New {
         long = "dialect",
         short = "d"
     )]
-    dialect: Option<String>
+    dialect: Option<String>,
 }
 
 impl Cmd for New {

--- a/dove/src/cmd/new.rs
+++ b/dove/src/cmd/new.rs
@@ -26,6 +26,13 @@ pub struct New {
         short = "a"
     )]
     address: Option<String>,
+    #[structopt(
+        help = "Compiler dialect",
+        name = "Dialect",
+        long = "dialect",
+        short = "d"
+    )]
+    dialect: Option<String>
 }
 
 impl Cmd for New {
@@ -44,7 +51,7 @@ impl Cmd for New {
         fs::create_dir(&project_dir)?;
 
         ctx.project_dir = project_dir;
-        let init = Init::new(self.repository, self.address);
+        let init = Init::new(self.repository, self.address, self.dialect);
         init.apply(ctx)
     }
 }

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -40,7 +40,7 @@ impl Context {
             .package
             .account_address
             .clone()
-            .ok_or(anyhow!("couldn't read account address from manifest"))?;
+            .ok_or_else(|| anyhow!("couldn't read account address from manifest"))?;
 
         self.dialect.normalize_account_address(&acc_addr)
     }

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -35,8 +35,8 @@ impl Context {
 
     /// Returns provided account address.
     pub fn account_address(&self) -> Result<ProvidedAccountAddress> {
-        self.dialect
-            .normalize_account_address(&format!("0x{}", &self.manifest.package.account_address))
+        let acc_addr = self.manifest.package.account_address.clone().unwrap(); 
+        self.dialect.normalize_account_address(&acc_addr)
     }
 }
 

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -1,5 +1,5 @@
 use std::path::{PathBuf, Path};
-use crate::manifest::{DoveToml, MANIFEST, read_manifest};
+use crate::manifest::{DoveToml, MANIFEST, read_manifest, default_dialect};
 use std::str::FromStr;
 use anyhow::{Result, anyhow};
 use std::env;
@@ -45,7 +45,7 @@ pub fn create_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
     let manifest = DoveToml::default();
 
-    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {
@@ -60,7 +60,7 @@ pub fn get_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
     let manifest = load_manifest(&project_dir)?;
 
-    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -35,7 +35,13 @@ impl Context {
 
     /// Returns provided account address.
     pub fn account_address(&self) -> Result<ProvidedAccountAddress> {
-        let acc_addr = self.manifest.package.account_address.clone().unwrap();
+        let acc_addr = self
+            .manifest
+            .package
+            .account_address
+            .clone()
+            .ok_or(anyhow!("couldn't read account address from manifest"))?;
+
         self.dialect.normalize_account_address(&acc_addr)
     }
 }

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -1,9 +1,9 @@
 use std::path::{PathBuf, Path};
 use crate::manifest::{DoveToml, MANIFEST, read_manifest};
+use std::str::FromStr;
 use anyhow::{Result, anyhow};
 use std::env;
-use lang::compiler::dialects::Dialect;
-use lang::compiler::dialects::dfinance::DFinanceDialect;
+use lang::compiler::dialects::{Dialect, DialectName};
 use lang::compiler::address::ProvidedAccountAddress;
 
 /// Project context.
@@ -43,10 +43,15 @@ impl Context {
 /// Create a new context for the current directory.
 pub fn create_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
+    let manifest = DoveToml::default();
+
+    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+    let dialect = DialectName::from_str(&dialect_name)?;
+
     Ok(Context {
         project_dir,
-        manifest: DoveToml::default(),
-        dialect: Box::new(DFinanceDialect::default()),
+        manifest,
+        dialect: dialect.get_dialect(),
     })
 }
 
@@ -55,10 +60,13 @@ pub fn get_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
     let manifest = load_manifest(&project_dir)?;
 
+    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+    let dialect = DialectName::from_str(&dialect_name)?;
+
     Ok(Context {
         project_dir,
         manifest,
-        dialect: Box::new(DFinanceDialect::default()),
+        dialect: dialect.get_dialect(),
     })
 }
 

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -35,7 +35,7 @@ impl Context {
 
     /// Returns provided account address.
     pub fn account_address(&self) -> Result<ProvidedAccountAddress> {
-        let acc_addr = self.manifest.package.account_address.clone().unwrap(); 
+        let acc_addr = self.manifest.package.account_address.clone().unwrap();
         self.dialect.normalize_account_address(&acc_addr)
     }
 }
@@ -45,7 +45,11 @@ pub fn create_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
     let manifest = DoveToml::default();
 
-    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
+    let dialect_name = manifest
+        .package
+        .dialect
+        .clone()
+        .unwrap_or_else(|| default_dialect());
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {
@@ -60,7 +64,11 @@ pub fn get_context() -> Result<Context> {
     let project_dir = env::current_dir()?;
     let manifest = load_manifest(&project_dir)?;
 
-    let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
+    let dialect_name = manifest
+        .package
+        .dialect
+        .clone()
+        .unwrap_or_else(|| default_dialect());
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {

--- a/dove/src/context.rs
+++ b/dove/src/context.rs
@@ -49,7 +49,7 @@ pub fn create_context() -> Result<Context> {
         .package
         .dialect
         .clone()
-        .unwrap_or_else(|| default_dialect());
+        .unwrap_or_else(default_dialect);
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {
@@ -68,7 +68,7 @@ pub fn get_context() -> Result<Context> {
         .package
         .dialect
         .clone()
-        .unwrap_or_else(|| default_dialect());
+        .unwrap_or_else(default_dialect);
     let dialect = DialectName::from_str(&dialect_name)?;
 
     Ok(Context {

--- a/dove/src/index/mod.rs
+++ b/dove/src/index/mod.rs
@@ -107,7 +107,7 @@ impl<'a> Index<'a> {
             if path.is_file() {
                 let f_meta = source_meta(
                     path,
-                    Some(self.ctx.manifest.package.account_address),
+                    Some(self.ctx.account_address()?.as_account_address()),
                     self.ctx.dialect.as_ref(),
                 )?;
                 for meta in f_meta.meta {
@@ -118,7 +118,7 @@ impl<'a> Index<'a> {
                 for mv_file in move_dir_iter(path) {
                     let f_meta = source_meta(
                         mv_file.path(),
-                        Some(self.ctx.manifest.package.account_address),
+                        Some(self.ctx.account_address()?.as_account_address()),
                         self.ctx.dialect.as_ref(),
                     )?;
 
@@ -216,7 +216,7 @@ impl<'a> Index<'a> {
         for file in move_dir_iter(path) {
             let meta = source_meta(
                 file.path(),
-                Some(self.ctx.manifest.package.account_address),
+                Some(self.ctx.account_address()?.as_account_address()),
                 self.ctx.dialect.as_ref(),
             )?;
 

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -83,7 +83,6 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
         let acc_addr = manifest
             .package
             .account_address
-            .clone()
             .ok_or(anyhow!("couldn't read account address from manifest"))?;
 
         let provided_account_address = dialect.normalize_account_address(&acc_addr)?;

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -80,8 +80,13 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
             .unwrap_or_else(default_dialect);
         let dialect = DialectName::from_str(&dialect_name)?.get_dialect();
 
-        let provided_account_address =
-            dialect.normalize_account_address(&manifest.package.account_address.unwrap())?;
+        let acc_addr = manifest
+            .package
+            .account_address
+            .clone()
+            .ok_or(anyhow!("couldn't read account address from manifest"))?;
+
+        let provided_account_address = dialect.normalize_account_address(&acc_addr)?;
 
         Ok(Some(provided_account_address.as_account_address()))
     } else {

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -72,12 +72,17 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
     let manifest = path.join(MANIFEST);
     if manifest.exists() {
         let manifest = read_manifest(&manifest)?;
-        
-        let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
+
+        let dialect_name = manifest
+            .package
+            .dialect
+            .clone()
+            .unwrap_or_else(|| default_dialect());
         let dialect = DialectName::from_str(&dialect_name)?.get_dialect();
 
-        let provided_account_address = dialect.normalize_account_address(&manifest.package.account_address.clone().unwrap())?;
-        
+        let provided_account_address = dialect
+            .normalize_account_address(&manifest.package.account_address.clone().unwrap())?;
+
         Ok(Some(provided_account_address.as_account_address()))
     } else {
         Ok(None)

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -1,5 +1,5 @@
 use std::path::{PathBuf, Path};
-use crate::manifest::{Git, MANIFEST, read_manifest};
+use crate::manifest::{Git, MANIFEST, read_manifest, default_dialect};
 use crate::context::Context;
 use git2::build::RepoBuilder;
 use tiny_keccak::{Sha3, Hasher};
@@ -73,7 +73,7 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
     if manifest.exists() {
         let manifest = read_manifest(&manifest)?;
         
-        let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+        let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| default_dialect());
         let dialect = DialectName::from_str(&dialect_name)?.get_dialect();
 
         let provided_account_address = dialect.normalize_account_address(&manifest.package.account_address.clone().unwrap())?;

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -77,11 +77,11 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
             .package
             .dialect
             .clone()
-            .unwrap_or_else(|| default_dialect());
+            .unwrap_or_else(default_dialect);
         let dialect = DialectName::from_str(&dialect_name)?.get_dialect();
 
-        let provided_account_address = dialect
-            .normalize_account_address(&manifest.package.account_address.clone().unwrap())?;
+        let provided_account_address =
+            dialect.normalize_account_address(&manifest.package.account_address.unwrap())?;
 
         Ok(Some(provided_account_address.as_account_address()))
     } else {

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -83,7 +83,7 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
         let acc_addr = manifest
             .package
             .account_address
-            .ok_or(anyhow!("couldn't read account address from manifest"))?;
+            .ok_or_else(|| anyhow!("couldn't read account address from manifest"))?;
 
         let provided_account_address = dialect.normalize_account_address(&acc_addr)?;
 

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -7,6 +7,8 @@ use anyhow::Error;
 use git2::{Repository, Oid};
 use crate::index::move_dir_iter;
 use libra::account::AccountAddress;
+use std::str::FromStr;
+use lang::compiler::dialects::{DialectName};
 use crate::index::meta::{source_meta, FileMeta};
 
 /// Git prefix.
@@ -70,7 +72,13 @@ fn get_dep_address(path: &Path) -> Result<Option<AccountAddress>, Error> {
     let manifest = path.join(MANIFEST);
     if manifest.exists() {
         let manifest = read_manifest(&manifest)?;
-        Ok(Some(manifest.package.account_address))
+        
+        let dialect_name = manifest.package.dialect.clone().unwrap_or_else(|| String::from("dfinance"));
+        let dialect = DialectName::from_str(&dialect_name)?.get_dialect();
+
+        let provided_account_address = dialect.normalize_account_address(&manifest.package.account_address.clone().unwrap())?;
+        
+        Ok(Some(provided_account_address.as_account_address()))
     } else {
         Ok(None)
     }

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -41,6 +41,8 @@ pub struct Package {
     pub blockchain_api: Option<String>,
     /// Dependency list.
     pub dependencies: Option<Dependencies>,
+    /// Dialect
+    pub dialect: Option<String>,
 }
 
 impl Default for Package {
@@ -51,6 +53,7 @@ impl Default for Package {
             authors: Default::default(),
             blockchain_api: None,
             dependencies: None,
+            dialect: None,
         }
     }
 }
@@ -277,6 +280,7 @@ mod test {
                     }),
                 ],
             }),
+            dialect: Some("dfinance".to_owned()),
         }
     }
 

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -56,7 +56,7 @@ impl Default for Package {
 }
 
 fn dialect() -> Option<String> {
-    Some("dfinance".to_owned())
+    Some(default_dialect())
 }
 
 fn module_dir() -> String {
@@ -241,6 +241,11 @@ impl Serialize for Dependencies {
 /// Reads the manifest by path.
 pub fn read_manifest(path: &Path) -> Result<DoveToml, Error> {
     Ok(toml::from_str(&fs::read_to_string(path)?)?)
+}
+
+/// Default dialect name (dfinance).
+pub fn default_dialect() -> String {
+    "dfinance".to_owned()
 }
 
 #[cfg(test)]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -46,6 +46,10 @@ regex = "1.3.7"
 lazy_static = "1.4.0"
 bech32 = "0.7.2"
 
+# ss58 prefix
+blake2-rfc = "0.2.18"
+rust-base58 = "0.0.4"
+
 [dev-dependencies]
 include_dir = "0.6.0"
 

--- a/lang/src/compiler/dialects/dfinance/mod.rs
+++ b/lang/src/compiler/dialects/dfinance/mod.rs
@@ -21,7 +21,7 @@ pub struct DFinanceDialect;
 
 impl Dialect for DFinanceDialect {
     fn name(&self) -> &str {
-        "dfinance"
+        "dfinance"  
     }
 
     fn normalize_account_address(&self, addr: &str) -> Result<ProvidedAccountAddress> {

--- a/lang/src/compiler/dialects/dfinance/mod.rs
+++ b/lang/src/compiler/dialects/dfinance/mod.rs
@@ -21,7 +21,7 @@ pub struct DFinanceDialect;
 
 impl Dialect for DFinanceDialect {
     fn name(&self) -> &str {
-        "dfinance"  
+        "dfinance"
     }
 
     fn normalize_account_address(&self, addr: &str) -> Result<ProvidedAccountAddress> {

--- a/lang/src/compiler/dialects/mod.rs
+++ b/lang/src/compiler/dialects/mod.rs
@@ -1,7 +1,7 @@
 pub mod dfinance;
 pub mod libra;
-pub mod polkadot;
 pub mod line_endings;
+pub mod polkadot;
 
 use anyhow::Result;
 use move_core_types::gas_schedule::CostTable;
@@ -27,7 +27,7 @@ pub trait Dialect {
 pub enum DialectName {
     Libra,
     DFinance,
-    Polkadot
+    Polkadot,
 }
 
 impl DialectName {

--- a/lang/src/compiler/dialects/mod.rs
+++ b/lang/src/compiler/dialects/mod.rs
@@ -1,5 +1,6 @@
 pub mod dfinance;
 pub mod libra;
+pub mod polkadot;
 pub mod line_endings;
 
 use anyhow::Result;
@@ -8,6 +9,7 @@ use crate::compiler::source_map::FileOffsetMap;
 use std::str::FromStr;
 use crate::compiler::dialects::libra::LibraDialect;
 use crate::compiler::dialects::dfinance::DFinanceDialect;
+use crate::compiler::dialects::polkadot::PolkadotDialect;
 use crate::compiler::address::ProvidedAccountAddress;
 
 pub trait Dialect {
@@ -25,6 +27,7 @@ pub trait Dialect {
 pub enum DialectName {
     Libra,
     DFinance,
+    Polkadot
 }
 
 impl DialectName {
@@ -32,6 +35,7 @@ impl DialectName {
         match self {
             DialectName::Libra => Box::new(LibraDialect::default()),
             DialectName::DFinance => Box::new(DFinanceDialect::default()),
+            DialectName::Polkadot => Box::new(PolkadotDialect::default()),
         }
     }
 }
@@ -43,6 +47,7 @@ impl FromStr for DialectName {
         match s {
             "libra" => Ok(DialectName::Libra),
             "dfinance" => Ok(DialectName::DFinance),
+            "polkadot" => Ok(DialectName::Polkadot),
             _ => Err(anyhow::format_err!("Invalid dialect {:?}", s)),
         }
     }

--- a/lang/src/compiler/dialects/polkadot/mod.rs
+++ b/lang/src/compiler/dialects/polkadot/mod.rs
@@ -1,0 +1,43 @@
+use crate::compiler::dialects::Dialect;
+use crate::compiler::source_map::FileOffsetMap;
+use move_core_types::account_address::AccountAddress;
+use anyhow::Context;
+use anyhow::Result;
+use move_core_types::gas_schedule::CostTable;
+use std::ops::Deref;
+use crate::compiler::address::ProvidedAccountAddress;
+use crate::compiler::ss58::{replace_ss58_addresses, ss58_to_libra};
+
+#[derive(Default)]
+pub struct PolkadotDialect;
+
+impl Dialect for PolkadotDialect {
+    fn name(&self) -> &str {
+        "polkadot"  
+    }
+
+    fn normalize_account_address(&self, addr: &str) -> Result<ProvidedAccountAddress> {
+        let address_res = if let Ok(libra_addr) = ss58_to_libra(addr) {
+            Ok(ProvidedAccountAddress::new(addr.to_string(), addr.to_string(), libra_addr))
+        } else if addr.starts_with("0x") {
+            AccountAddress::from_hex_literal(addr).map(|address| {
+                let lowered_addr = format!("0x{}", address);
+                ProvidedAccountAddress::new(addr.to_string(), lowered_addr.clone(), lowered_addr)
+            })
+        } else {
+            Err(anyhow::anyhow!("Does not start with either wallet1 or 0x"))
+        };
+        address_res.with_context(|| format!("Address {:?} is not a valid dfinance address", addr))
+    }
+
+    fn cost_table(&self) -> CostTable {
+        // TODO: make compatible with Polkadot gas table.
+        vm_genesis::genesis_gas_schedule::INITIAL_GAS_SCHEDULE
+            .deref()
+            .clone()
+    }
+
+    fn replace_addresses(&self, source_text: &str, source_map: &mut FileOffsetMap) -> String {
+        replace_ss58_addresses(&source_text, source_map)
+    }
+}

--- a/lang/src/compiler/dialects/polkadot/mod.rs
+++ b/lang/src/compiler/dialects/polkadot/mod.rs
@@ -25,9 +25,9 @@ impl Dialect for PolkadotDialect {
                 ProvidedAccountAddress::new(addr.to_string(), lowered_addr.clone(), lowered_addr)
             })
         } else {
-            Err(anyhow::anyhow!("Does not start with either wallet1 or 0x"))
+            Err(anyhow::anyhow!("Address is not valid libra or polkadot address"))
         };
-        address_res.with_context(|| format!("Address {:?} is not a valid dfinance address", addr))
+        address_res.with_context(|| format!("Address {:?} is not a valid libra/polkadot address", addr))
     }
 
     fn cost_table(&self) -> CostTable {

--- a/lang/src/compiler/dialects/polkadot/mod.rs
+++ b/lang/src/compiler/dialects/polkadot/mod.rs
@@ -13,21 +13,28 @@ pub struct PolkadotDialect;
 
 impl Dialect for PolkadotDialect {
     fn name(&self) -> &str {
-        "polkadot"  
+        "polkadot"
     }
 
     fn normalize_account_address(&self, addr: &str) -> Result<ProvidedAccountAddress> {
         let address_res = if let Ok(libra_addr) = ss58_to_libra(addr) {
-            Ok(ProvidedAccountAddress::new(addr.to_string(), addr.to_string(), libra_addr))
+            Ok(ProvidedAccountAddress::new(
+                addr.to_string(),
+                addr.to_string(),
+                libra_addr,
+            ))
         } else if addr.starts_with("0x") {
             AccountAddress::from_hex_literal(addr).map(|address| {
                 let lowered_addr = format!("0x{}", address);
                 ProvidedAccountAddress::new(addr.to_string(), lowered_addr.clone(), lowered_addr)
             })
         } else {
-            Err(anyhow::anyhow!("Address is not valid libra or polkadot address"))
+            Err(anyhow::anyhow!(
+                "Address is not valid libra or polkadot address"
+            ))
         };
-        address_res.with_context(|| format!("Address {:?} is not a valid libra/polkadot address", addr))
+        address_res
+            .with_context(|| format!("Address {:?} is not a valid libra/polkadot address", addr))
     }
 
     fn cost_table(&self) -> CostTable {

--- a/lang/src/compiler/mod.rs
+++ b/lang/src/compiler/mod.rs
@@ -6,6 +6,7 @@ pub mod file;
 pub mod location;
 pub mod parser;
 pub mod source_map;
+pub mod ss58;
 
 pub use anyhow::Result;
 pub use move_lang::name_pool::ConstPool;

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -1,9 +1,7 @@
 use rust_base58::base58::FromBase58;
-use hex;
 use anyhow::{anyhow, ensure, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
-use blake2_rfc;
 use crate::compiler::source_map::FileOffsetMap;
 
 const SS58_PREFIX: &[u8] = b"SS58PRE";
@@ -37,7 +35,7 @@ pub fn ss58_to_libra(ss58: &str) -> Result<String> {
     }
     addr[..2].copy_from_slice(&[bs58[0], 0]);
     addr[2..].copy_from_slice(&bs58[1..PUB_KEY_LENGTH / 2 + 1]);
-    Ok(format!("0x{}", hex::encode_upper(addr).to_string()))
+    Ok(format!("0x{}", hex::encode_upper(addr)))
 }
 
 pub fn replace_ss58_addresses(source: &str, file_source_map: &mut FileOffsetMap) -> String {

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -29,12 +29,12 @@ pub fn ss58_to_libra(ss58: &str) -> Result<String> {
         Err(_) => return Err(anyhow!("Wrong base58"))
     };
     ensure!(bs58.len() == PUB_KEY_LENGTH+3, format!("Address length must be equal {} bytes", PUB_KEY_LENGTH+3));
-    let mut addr = [0; 16];
+    let mut addr = [0; 34];
     if bs58[PUB_KEY_LENGTH + 1..PUB_KEY_LENGTH + 3] != ss58hash(&bs58[0..PUB_KEY_LENGTH + 1]).as_bytes()[0..2] {
         return Err(anyhow!("Wrong address checksum"))
     }
-    //addr[..2].copy_from_slice(&[bs58[0], 0]);
-    addr.copy_from_slice(&bs58[1..PUB_KEY_LENGTH/2+1]);
+    addr[..2].copy_from_slice(&[bs58[0], 0]);
+    addr[2..].copy_from_slice(&bs58[1..PUB_KEY_LENGTH/2+1]);
     Ok(format!("0x{}", hex::encode_upper(addr).to_string()))
 }
 

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -66,9 +66,7 @@ pub fn replace_ss58_addresses(source: &str, file_source_map: &mut FileOffsetMap)
 #[cfg(test)]
 mod test {
     use crate::compiler::source_map::FileOffsetMap;
-
     use super::{ss58_to_libra, ss58hash, replace_ss58_addresses};
-    use hex;
 
     #[test]
     fn test_ss58_to_libra() {
@@ -83,7 +81,7 @@ mod test {
 
     #[test]
     fn test_ss58hash() {
-        let msg = "hello, world!".as_bytes();
+        let msg = b"hello, world!";
         let hash = ss58hash(msg).as_bytes().to_vec();
 
         assert_eq!("656facfcf4f90cce9ec9b65c9185ea75346507c67e25133f5809b442487468a674973f9167193e86bee0c706f6766f7edf638ed3e21ad12c2908ea62924af4d7", hex::encode(hash));

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -42,7 +42,9 @@ pub fn replace_ss58_addresses(source: &str, file_source_map: &mut FileOffsetMap)
     let mut transformed_source = source.to_string();
 
     for mat in SS58_REGEX.captures_iter(source).into_iter() {
-        let item = mat.get(0).unwrap();
+        let item = mat
+            .get(0)
+            .expect("can't extract match from SS58 regex capture");
 
         let orig_address = item.as_str();
         if orig_address.starts_with("0x") {

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -1,0 +1,65 @@
+use rust_base58::base58::FromBase58;
+use hex;
+use anyhow::{anyhow, ensure, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+use blake2_rfc;
+use crate::compiler::source_map::FileOffsetMap;
+
+const SS58_PREFIX: &[u8]    = b"SS58PRE";
+const PUB_KEY_LENGTH: usize = 32;
+
+lazy_static! {
+    static ref SS58_REGEX: Regex = Regex::new(
+        r#"[1-9A-HJ-NP-Za-km-z]{40,}"#,
+    )
+    .unwrap();
+}
+
+// Generate blake2 256 hash (we use only 2).
+fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
+	let mut context = blake2_rfc::blake2b::Blake2b::new(64);
+	context.update(SS58_PREFIX);
+	context.update(data);
+	context.finalize()
+}
+
+// Address is 1 byte (account_type) + 32 bytes (public key) + 2 bytes (checksum).
+// We reserve 1 additional byte for account_type for future.
+pub fn ss58_to_libra(ss58: &str) -> Result<String> {
+    let bs58 = match ss58.from_base58() {
+        Ok(bs58) => bs58,
+        Err(_) => return Err(anyhow!("Wrong base58"))
+    };
+    ensure!(bs58.len() == PUB_KEY_LENGTH+3, format!("Address length must be equal {} bytes", PUB_KEY_LENGTH+3));
+    let mut addr = [0; 34];
+    if bs58[PUB_KEY_LENGTH + 1..PUB_KEY_LENGTH + 3] != ss58hash(&bs58[0..PUB_KEY_LENGTH + 1]).as_bytes()[0..2] {
+        return Err(anyhow!("Wrong address checksum"))
+    }
+    addr[..2].copy_from_slice(&[bs58[0], 0]);
+    addr[2..].copy_from_slice(&bs58[1..PUB_KEY_LENGTH+1]);
+    Ok(format!("0x{}", hex::encode_upper(addr).to_string()))
+}
+
+pub fn replace_ss58_addresses(source: &str, file_source_map: &mut FileOffsetMap) -> String {
+    let mut transformed_source = source.to_string();
+
+    for mat in SS58_REGEX.captures_iter(source).into_iter() {
+        let item = mat.get(0).unwrap();
+
+        let orig_address = item.as_str();
+        if orig_address.starts_with("0x") {
+            // libra match, don't replace
+            continue;
+        }
+        if let Ok(libra_address) = ss58_to_libra(orig_address) {
+            file_source_map.insert_address_layer(
+                item.end(),
+                orig_address.to_owned(),
+                libra_address.clone(),
+            );
+            transformed_source = transformed_source.replace(orig_address, &libra_address);
+        }
+    }
+    transformed_source
+}

--- a/lang/src/compiler/ss58.rs
+++ b/lang/src/compiler/ss58.rs
@@ -16,7 +16,6 @@ lazy_static! {
     .unwrap();
 }
 
-// Generate blake2 256 hash (we use only 2).
 fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 	let mut context = blake2_rfc::blake2b::Blake2b::new(64);
 	context.update(SS58_PREFIX);
@@ -24,20 +23,18 @@ fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 	context.finalize()
 }
 
-// Address is 1 byte (account_type) + 32 bytes (public key) + 2 bytes (checksum).
-// We reserve 1 additional byte for account_type for future.
 pub fn ss58_to_libra(ss58: &str) -> Result<String> {
     let bs58 = match ss58.from_base58() {
         Ok(bs58) => bs58,
         Err(_) => return Err(anyhow!("Wrong base58"))
     };
     ensure!(bs58.len() == PUB_KEY_LENGTH+3, format!("Address length must be equal {} bytes", PUB_KEY_LENGTH+3));
-    let mut addr = [0; 34];
+    let mut addr = [0; 16];
     if bs58[PUB_KEY_LENGTH + 1..PUB_KEY_LENGTH + 3] != ss58hash(&bs58[0..PUB_KEY_LENGTH + 1]).as_bytes()[0..2] {
         return Err(anyhow!("Wrong address checksum"))
     }
-    addr[..2].copy_from_slice(&[bs58[0], 0]);
-    addr[2..].copy_from_slice(&bs58[1..PUB_KEY_LENGTH+1]);
+    //addr[..2].copy_from_slice(&[bs58[0], 0]);
+    addr.copy_from_slice(&bs58[1..PUB_KEY_LENGTH/2+1]);
     Ok(format!("0x{}", hex::encode_upper(addr).to_string()))
 }
 


### PR DESCRIPTION
* Supports ss58 address.
* Choose different dialects using dove (using manifest or -d/--dialect), e.g.:
`dove new -d polkadot tst`
* Manifest deserialize/serialize address as string now, later i use dialect to get real account address
* Default dialect - dfinance.
* **Polkadot dialect doesn't work because of address length of 34 bytes.**